### PR TITLE
Add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md LICENSE
+graft parquet

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extensions = [Extension("parquet._optimized", sourcefiles)]
 
 setup(
     name='parquet',
-    version='1.0',
+    version='1.0.0a2',
     description='Python support for Parquet file format',
     author='Joe Crobak',
     author_email='joecrow@gmail.com',


### PR DESCRIPTION
Without manifest it is not possible to install this package from PiPY, because *.pyx or *.c files are not included